### PR TITLE
When event is received, clear notifications

### DIFF
--- a/console/src/main/java/org/matrix/console/services/EventStreamService.java
+++ b/console/src/main/java/org/matrix/console/services/EventStreamService.java
@@ -180,6 +180,17 @@ public class EventStreamService extends Service {
         }
 
         @Override
+        public void onReceiptEvent(String roomId, List<String> senderIds) {
+            Log.i(LOG_TAG, String.format("Room Id \"%s\" has been read by %s", roomId, senderIds));
+            for (String sender : senderIds) {
+                if (mMatrixIds.contains(sender)) {
+                    cancelNotifications(roomId);
+                    return;
+                }
+            }
+        }
+
+        @Override
         public void onBingEvent(Event event, RoomState roomState, BingRule bingRule) {
             Log.i(LOG_TAG, "onMessageEvent >>>> " + event);
 


### PR DESCRIPTION
Duplicate from #18, but into correct branch.
Original comment:

> This works awesomely if there's only one user on the android app.
> If there's multiple users on the app, then (due to a pre-existing bug), no notifications appear for the other user.
